### PR TITLE
Add Sproto Gremlin Telegram bot MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,7 @@ coverage/
 *.pem
 *.key
 credentials.json
-secrets.json 
+secrets.json
+feedback.csv
+
+

--- a/README.md
+++ b/README.md
@@ -1,33 +1,37 @@
 # AQUATWEETS
 
-A project for managing and analyzing aquatic-themed tweets and social media content.
-
-## Description
-
-AQUATWEETS is designed to help track, analyze, and share water-related content on social media platforms.
+This repository contains the code for **Sproto Gremlin Bot**, a Telegram DM bot that rewrites your thoughts in the voice of the Sproto Gremlin. It responds to the `/sproto` command with two tweet-style variants and lets you give feedback via 👍/👎 buttons.
 
 ## Features
 
-- Coming soon...
+- Runs in private Telegram chats
+- Uses a local system prompt stored in `prompt.txt`
+- Generates two variations for each `/sproto` command using a transformers-based LLM
+- Records feedback in `feedback.csv`
+
+## Requirements
+
+- Python 3.8+
+- The packages listed in `requirements.txt`
+- A Telegram bot token set in the `TELEGRAM_TOKEN` environment variable
+
+Optional: set `MODEL_NAME` to choose a HuggingFace model and `PROMPT_PATH` to use a custom prompt file.
 
 ## Installation
 
 ```bash
-# Clone the repository
-git clone https://github.com/yourusername/AQUATWEETS.git
-cd AQUATWEETS
-
-# Install dependencies (to be added)
+pip install -r requirements.txt
 ```
 
 ## Usage
 
-Details coming soon...
+1. Set `TELEGRAM_TOKEN` in your environment.
+2. Run the bot:
 
-## Contributing
+```bash
+python bot.py
+```
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Send `/sproto your text` to the bot in a DM and it will reply with two gremlin-style tweets. Click 👍 or 👎 under each message to record feedback.
 
-## License
-
-This project is licensed under the MIT License - see the LICENSE file for details. 
+Feedback is appended to `feedback.csv` for later analysis.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,70 @@
+import os
+import csv
+from datetime import datetime
+from typing import List
+
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import ApplicationBuilder, CommandHandler, CallbackQueryHandler, ContextTypes
+from telegram.ext import MessageHandler, filters
+
+from transformers import pipeline
+
+# Load environment variables
+TOKEN = os.getenv("TELEGRAM_TOKEN")
+MODEL_NAME = os.getenv("MODEL_NAME", "gpt2")
+PROMPT_PATH = os.getenv("PROMPT_PATH", "prompt.txt")
+
+if TOKEN is None:
+    raise RuntimeError("TELEGRAM_TOKEN environment variable not set")
+
+# Load system prompt
+with open(PROMPT_PATH, "r", encoding="utf-8") as f:
+    SYSTEM_PROMPT = f.read().strip()
+
+# Load text generation pipeline
+text_generator = pipeline("text-generation", model=MODEL_NAME)
+
+def generate_variants(user_text: str, n: int = 2) -> List[str]:
+    prompt = f"{SYSTEM_PROMPT}\nUser: {user_text}\nGremlin:" 
+    outputs = text_generator(prompt, max_new_tokens=len(user_text.split()) + 5, num_return_sequences=n, do_sample=True, temperature=0.8)
+    variants = []
+    for out in outputs:
+        text = out["generated_text"].split("Gremlin:")[-1].strip()
+        variants.append(text)
+    return variants
+
+async def sproto_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    user_input = update.message.text
+    if not user_input:
+        return
+    text = user_input[len('/sproto'):].strip().strip('"')
+    if not text:
+        await update.message.reply_text("Usage: /sproto your text here")
+        return
+    variants = generate_variants(text, n=2)
+    for i, variant in enumerate(variants, start=1):
+        keyboard = InlineKeyboardMarkup([
+            [InlineKeyboardButton("👍", callback_data=f"up|{variant}"),
+             InlineKeyboardButton("👎", callback_data=f"down|{variant}")]
+        ])
+        await update.message.reply_text(variant, reply_markup=keyboard)
+
+async def feedback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    vote, text = query.data.split("|", 1)
+    user = update.effective_user.id
+    with open("feedback.csv", "a", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow([datetime.utcnow().isoformat(), user, vote, text])
+    await query.edit_message_reply_markup(reply_markup=None)
+
+async def main() -> None:
+    app = ApplicationBuilder().token(TOKEN).build()
+    app.add_handler(CommandHandler("sproto", sproto_command))
+    app.add_handler(CallbackQueryHandler(feedback_handler))
+    app.run_polling()
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())

--- a/prompt.txt
+++ b/prompt.txt
@@ -1,0 +1,1 @@
+You are Sproto Gremlin, the mischievous mascot of HarryPotterObamaSonic10Inu coin. Rephrase the user's thought in a playful crypto gremlin style. Keep it roughly the same length and sentiment. Respond with tweet-ready text.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+python-telegram-bot==20.7
+transformers==4.35.2
+accelerate==0.24.1


### PR DESCRIPTION
## Summary
- add simple Telegram bot using python-telegram-bot
- generate messages with a Transformers text generation model
- store the system prompt in `prompt.txt`
- log feedback to `feedback.csv`
- add install and usage details to README

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6872f924397083249a44cf541e1373e7