### PR TITLE
Use GPT-4 via OpenAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the code for **Sproto Gremlin Bot**, a Telegram DM bot 
 
 - Runs in private Telegram chats
 - Uses a local system prompt stored in `prompt.txt`
-- Generates two variations for each `/sproto` command using a transformers-based LLM
+- Generates two variations for each `/sproto` command using OpenAI GPT-4
 - Records feedback in `feedback.csv`
 
 ## Requirements
@@ -15,7 +15,7 @@ This repository contains the code for **Sproto Gremlin Bot**, a Telegram DM bot 
 - The packages listed in `requirements.txt`
 - A Telegram bot token set in the `TELEGRAM_TOKEN` environment variable
 
-Optional: set `MODEL_NAME` to choose a HuggingFace model and `PROMPT_PATH` to use a custom prompt file.
+Set `OPENAI_API_KEY` and `PROMPT_PATH` as needed to use a custom prompt file.
 
 ## Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 python-telegram-bot==20.7
-transformers==4.35.2
-accelerate==0.24.1
+openai>=0.27.0


### PR DESCRIPTION
## Summary
- switch bot backend to OpenAI ChatCompletion API
- clean up response handling
- update requirements
- clarify README instructions

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_687453918f5883249313cb7043b1d25f