### PR TITLE
Use GPT-4 via OpenAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the code for **Sproto Gremlin Bot**, a Telegram DM bot 
 
 - Runs in private Telegram chats
 - Uses a local system prompt stored in `prompt.txt`
-- Generates two variations for each `/sproto` command using a transformers-based LLM
+- Generates two variations for each `/sproto` command using OpenAI GPT-4
 - Records feedback in `feedback.csv`
 
 ## Requirements
@@ -15,13 +15,17 @@ This repository contains the code for **Sproto Gremlin Bot**, a Telegram DM bot 
 - The packages listed in `requirements.txt`
 - A Telegram bot token set in the `TELEGRAM_TOKEN` environment variable
 
-Optional: set `MODEL_NAME` to choose a HuggingFace model and `PROMPT_PATH` to use a custom prompt file.
+Set `OPENAI_API_KEY` and `PROMPT_PATH` as needed to use a custom prompt file.
 
 ## Installation
 
 ```bash
 pip install -r requirements.txt
 ```
+
+If you see `ModuleNotFoundError: No module named 'telegram'`, make sure you've
+installed the packages in the same Python environment by running the command
+above.
 
 ## Usage
 

--- a/bot.py
+++ b/bot.py
@@ -3,16 +3,20 @@ import csv
 from datetime import datetime
 from typing import List
 
-from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
-from telegram.ext import ApplicationBuilder, CommandHandler, CallbackQueryHandler, ContextTypes
-from telegram.ext import MessageHandler, filters
+try:
+    from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+    from telegram.ext import ApplicationBuilder, CommandHandler, CallbackQueryHandler, ContextTypes
+except ImportError as e:
+    raise ImportError(
+        "python-telegram-bot is required. Install dependencies with 'pip install -r requirements.txt'"
+    ) from e
 
-from transformers import pipeline
+import openai
 
 # Load environment variables
 TOKEN = os.getenv("TELEGRAM_TOKEN")
-MODEL_NAME = os.getenv("MODEL_NAME", "gpt2")
 PROMPT_PATH = os.getenv("PROMPT_PATH", "prompt.txt")
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 if TOKEN is None:
     raise RuntimeError("TELEGRAM_TOKEN environment variable not set")
@@ -21,8 +25,6 @@ if TOKEN is None:
 with open(PROMPT_PATH, "r", encoding="utf-8") as f:
     SYSTEM_PROMPT = f.read().strip()
 
-# Load text generation pipeline
-text_generator = pipeline("text-generation", model=MODEL_NAME)
 
 def generate_variants(user_text: str, n: int = 2) -> List[str]:
     variants = []
@@ -36,42 +38,26 @@ def generate_variants(user_text: str, n: int = 2) -> List[str]:
         f"Sproto vibes: {user_text} but with extra GREMLIN ENERGY! ⚡🐸💚"
     ]
     
-    # Try GPT-2 generation first
+    # Generate gremlin-style text using GPT-4
     try:
-        prompt = f"Rewrite this in a playful crypto gremlin style: {user_text}\n\nGremlin version:"
-        outputs = text_generator(
-            prompt, 
-            max_new_tokens=30,
-            num_return_sequences=n, 
-            do_sample=True, 
+        response = openai.ChatCompletion.create(
+            model="gpt-4",
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": user_text}
+            ],
             temperature=0.9,
-            pad_token_id=text_generator.tokenizer.eos_token_id,
-            repetition_penalty=1.2
+            n=n
         )
-        
-        for out in outputs:
-            full_text = out["generated_text"]
-            if "Gremlin version:" in full_text:
-                generated = full_text.split("Gremlin version:")[-1].strip()
-            else:
-                generated = full_text[len(prompt):].strip()
-            
-            # Clean up and validate
-            generated = generated.split('\n')[0].strip()  # Take first line only
-            
-            # Remove problematic patterns
-            if (generated and 
-                len(generated) > 5 and 
-                len(generated) < 200 and
-                not generated.startswith('http') and
-                not generated.startswith('[') and
-                not generated.startswith('@') and
-                'github.com' not in generated.lower() and
-                'bit.ly' not in generated.lower() and
-                't.co' not in generated.lower()):
-                variants.append(generated)
+        for choice in response.choices:
+            variant = choice.message.content.strip().split('\n')[0].strip()
+            if (variant and len(variant) > 5 and len(variant) < 280 and
+                    not variant.startswith('http') and
+                    not variant.startswith('[') and
+                    not variant.startswith('@')):
+                variants.append(variant)
     except Exception as e:
-        print(f"GPT-2 generation failed: {e}")
+        print(f"OpenAI API call failed: {e}")
     
     # Fill remaining slots with template responses
     import random

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-python-telegram-bot==20.7
-transformers==4.35.2
-accelerate==0.24.1
+python-telegram-bot>=22.2
+openai>=0.27.0


### PR DESCRIPTION
## Summary
- switch bot backend to OpenAI ChatCompletion API
- clean up response handling
- update requirements
- clarify README instructions and handle missing imports gracefully

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_687453918f5883249313cb7043b1d25f